### PR TITLE
Bug #168131 Fix: Backend > Issued Certificates > Warning displayed on…

### DIFF
--- a/src/components/com_tjcertificate/administrator/models/certificate.php
+++ b/src/components/com_tjcertificate/administrator/models/certificate.php
@@ -198,7 +198,7 @@ class TjCertificateModelCertificate extends AdminModel
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function delete($certificateIds)
+	public function delete(&$certificateIds)
 	{
 		$certificateIds  = (array) $certificateIds;
 		$table    = $this->getTable('Certificates');
@@ -244,7 +244,7 @@ class TjCertificateModelCertificate extends AdminModel
 	 * 
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function publish($ids, $state = 1)
+	public function publish(&$ids, $state = 1)
 	{
 		$table = $this->getTable();
 


### PR DESCRIPTION
… the certificate preview

 for delete() and publish()

Notices are as follows:
- Warning: Declaration of TjCertificateModelCertificate::delete($certificateIds) should be compatible with Joomla\CMS\MVC\Model\AdminModel::delete(&$pks) in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\models\certificate.php on line 201

- Warning: Declaration of TjCertificateModelCertificate::publish($ids, $state = 1) should be compatible with Joomla\CMS\MVC\Model\AdminModel::publish(&$pks, $value = 1) in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\models\certificate.php on line 247