### PR TITLE
Bug #170717 Fix: Frontend > My Certificate > Warnings and notices dis…

### DIFF
--- a/src/components/com_tjcertificate/administrator/views/certificate/tmpl/edit.php
+++ b/src/components/com_tjcertificate/administrator/views/certificate/tmpl/edit.php
@@ -68,8 +68,6 @@ elseif (!empty($client))
 		}
 		?>
 		<div class="form-horizontal">
-
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_TJCERTIFICATE_TITLE_CERTIFICATE')); ?>
 		<div class="row-fluid">
 			<?php echo $this->form->renderField('unique_certificate_id'); ?>
 			<?php echo $this->form->renderField('certificate_template_id'); ?>

--- a/src/components/com_tjcertificate/site/views/certificate/tmpl/default.php
+++ b/src/components/com_tjcertificate/site/views/certificate/tmpl/default.php
@@ -57,7 +57,8 @@ if ($this->showSearchBox)
 if ($this->certificate)
 {
 	$document = Factory::getDocument();
-	$description = $this->item->description ? $this->item->description : $this->item->short_desc;
+	$description = !empty($this->item->description) ? $this->item->description :
+	(!empty($this->item->short_desc)? $this->item->short_desc: '');
 	$document->addScriptDeclaration("var certRootUrl = '" . JUri::root() . "'");
 
 	// For facebook and linkedin


### PR DESCRIPTION
…played on the certificate detail view

**Notices are as follows:**
On my certificate:
1. Notice: Undefined property: JTicketingEventJticketing::$description in ~\components\com_tjcertificate\views\certificate\tmpl\default.php on line 60

2. Notice: Undefined property: JTicketingEventJticketing::$short_desc in ~\components\com_tjcertificate\views\certificate\tmpl\default.php on line 6

On issued certificate editing:
1. Notice: Undefined index: JHtmlBootstrap::startTabSet in ~\libraries\cms\html\bootstrap.php on line 798
2. Notice: Trying to access array offset on value of type null in ~\libraries\cms\html\bootstrap.php on line 798
3. Notice: Trying to access array offset on value of type null in ~\libraries\cms\html\bootstrap.php on line 798