### PR TITLE
Bug #172375 Fix: Backend > Issued Certificates > Bulk Training Record…

### DIFF
--- a/src/components/com_tjcertificate/administrator/libraries/certificate.php
+++ b/src/components/com_tjcertificate/administrator/libraries/certificate.php
@@ -562,7 +562,10 @@ class TjCertificateCertificate extends CMSObject
 		// Set private properties
 		foreach ($getPrivateProperties as $key => $value)
 		{
-			$this->{$value->name} = $array[$value->name];
+			if (!empty($array[$value->name]))
+			{
+				$this->{$value->name} = $array[$value->name];
+			}
 		}
 
 		// Make sure its an integer

--- a/src/components/com_tjcertificate/administrator/views/bulktrainingrecord/tmpl/edit.php
+++ b/src/components/com_tjcertificate/administrator/views/bulktrainingrecord/tmpl/edit.php
@@ -54,12 +54,13 @@ $message = Text::sprintf("COM_TJCERTIFICATE_USER_LIMIT_MESSAGE", $userLimit);
 		?>
 		<div class="form-horizontal">
 
-		<?php echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_TJCERTIFICATE_TITLE_CERTIFICATE')); ?>
+		<?php
+		echo HTMLHelper::_('bootstrap.startTabSet', 'myTab', array('active' => 'general'));
+		echo HTMLHelper::_('bootstrap.addTab', 'myTab', 'general', Text::_('COM_TJCERTIFICATE_TITLE_CERTIFICATE')); ?>
 		<div class="row-fluid">
 			<?php
 				if ($this->isAgencyEnabled)
 				{
-				
 					echo $this->form->renderField('agency_id');
 				}
 			?>


### PR DESCRIPTION
…s > On submitting the record, notices and deprecated errors displayed

Notices displayed are as below:
Notice: Undefined index: JHtmlBootstrap::startTabSet in C:\xampp\htdocs\JT\libraries\cms\html\bootstrap.php on line 798
Notice: Trying to access array offset on value of type null in C:\xampp\htdocs\JT\libraries\cms\html\bootstrap.php on line 798
Notice: Trying to access array offset on value of type null in C:\xampp\htdocs\JT\libraries\cms\html\bootstrap.php on line 798
Notice: Undefined index: certificate_template_id in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\certificate.php on line 565
Notice: Undefined index: client_id in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\certificate.php on line 565
Notice: Undefined index: client_issued_to in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\certificate.php on line 565
Notice: Undefined index: client_issued_to_name in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\certificate.php on line 565
Notice: Undefined index: comment in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\certificate.php on line 565
Deprecated: Non-static method TJCERT::getClient() should not be called statically in C:\xampp\htdocs\JT\administrator\components\com_tjcertificate\libraries\mails.php on line 55
