### PR TITLE
Bug #172379 Fix: In certification expiry , every time I take the lesson , it re-genrate the new issued date and exipry date, it should update the expiry date

### DIFF
--- a/src/components/com_tjcertificate/administrator/libraries/certificate.php
+++ b/src/components/com_tjcertificate/administrator/libraries/certificate.php
@@ -469,8 +469,25 @@ class TjCertificateCertificate extends CMSObject
 				return false;
 			}
 
+			$isNew = 0;
+
 			// Check if new record
-			$isNew = empty($this->id);
+			if (!empty($this->id))
+			{
+				$table->load(array('id' => (int) $this->id));
+			}
+			else
+			{
+				$isNew = 1;
+			}
+
+			if (isset($table->expired_on) && $table->expired_on != "0000-00-00 00:00:00")
+			{
+				$table->id = "";
+				$this->unique_certificate_id = "";
+				$table->expired_on = '0000-00-00 00:00:00';
+				$isNew = 1;
+			}
 
 			// Set current date if issued_on date is not set
 			if ($isNew && !$table->issued_on)

--- a/src/components/com_tjcertificate/administrator/libraries/certificate.php
+++ b/src/components/com_tjcertificate/administrator/libraries/certificate.php
@@ -483,10 +483,11 @@ class TjCertificateCertificate extends CMSObject
 
 			if (isset($table->expired_on) && $table->expired_on != "0000-00-00 00:00:00")
 			{
-				$table->id = "";
+				$isNew                       = 1;
+				$table->id                   = "";
 				$this->unique_certificate_id = "";
-				$table->expired_on = '0000-00-00 00:00:00';
-				$isNew = 1;
+				$table->issued_on            = Factory::getDate()->toSql();
+				$table->expired_on           = '0000-00-00 00:00:00';
 			}
 
 			// Set current date if issued_on date is not set


### PR DESCRIPTION
…on , it re-genrate the new issued date and exipry date, it should update the expiry date