### PR TITLE
Task #000000 chore : Bulk Course Assignment Failing Due to Database connection Limit

### DIFF
--- a/src/components/com_tjcertificate/administrator/controllers/bulktrainingrecord.json.php
+++ b/src/components/com_tjcertificate/administrator/controllers/bulktrainingrecord.json.php
@@ -91,7 +91,8 @@ class TjCertificateControllerBulkTrainingRecord extends FormController
 			$data['is_external'] = 1;
 
 			unset($data['assigned_user_id']);
-
+			$queueProducer = new TJQueueProduce;
+			
 			foreach ($userIds as $userId)
 			{
 				if (ComponentHelper::isEnabled($this->comMultiAgency) && $params->get('enable_multiagency'))
@@ -132,7 +133,7 @@ class TjCertificateControllerBulkTrainingRecord extends FormController
 				if (ComponentHelper::isEnabled('com_tjqueue') && $params->get('tjqueue_records'))
 				{
 					$recordsModel      = TJCERT::model('BulkTrainingRecord', array('ignore_request' => true));
-					$response          = $recordsModel->addToQueue($data);
+					$response          = $recordsModel->addToQueue($data, $queueProducer);
 					$msg               = $response ? Text::_("COM_TJCERTIFICATE_RECORDS_ADDED_TO_QUEUE_SUCCESSFULLY") : Text::_("COM_TJCERTIFICATE_RECORDS_FAILED");
 					$returnData['msg'] = $msg;
 				}

--- a/src/components/com_tjcertificate/administrator/controllers/bulktrainingrecord.json.php
+++ b/src/components/com_tjcertificate/administrator/controllers/bulktrainingrecord.json.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Component\ComponentHelper;
+use TJQueue\Admin\TJQueueProduce;
 
 /**
  * The Tj Certificate Training Records controller

--- a/src/components/com_tjcertificate/administrator/models/bulktrainingrecord.php
+++ b/src/components/com_tjcertificate/administrator/models/bulktrainingrecord.php
@@ -107,14 +107,14 @@ class TjCertificateModelBulkTrainingRecord extends AdminModel
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function addToQueue($data)
+	public function addToQueue($data, $queueProducer = null)
 	{
 		$return      = array();
 		$messageBody = (object) $data;
+		$TJQueueProduce = $queueProducer ?: new TJQueueProduce;
 
 		try
 		{
-			$TJQueueProduce = new TJQueueProduce;
 
 			// Set message body
 			$TJQueueProduce->message->setBody(json_encode($messageBody));


### PR DESCRIPTION
Issue Summary

A discrepancy was observed where 259 users were assigned to a course, but only 165 assignments appeared as completed. The remaining assignments were stuck in the queue due to a database connection limit issue.

Root Cause

The issue was caused by a SQLSTATE[08004] [1040] error, which occurs when the MySQL maximum connection limit is reached. During bulk course assignment, a large number of concurrent database connections were opened by long-running background processes. Once the server’s connection limit was exceeded, new requests were rejected, preventing the remaining users from being processed in the assignment queue.

Resolution

This MR updates the assignment logic to handle bulk processing more efficiently by reducing simultaneous database connections. With this change, the queue now processes all records correctly without hitting the MySQL connection limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved queue handling for bulk training operations by making the queue producer injectable, enhancing testability and maintainability.
  * Internal initialization timing adjusted; observable behavior and bulk processing workflow remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->